### PR TITLE
feat: Allow to create a Client by passing inline key and certs

### DIFF
--- a/client.go
+++ b/client.go
@@ -17,8 +17,19 @@ func NewClient(endpoint string) (*Client, error) {
 }
 
 // NewTLSClient create a client for a TLS secured Docker engine
+// The key and certificates are passed by filename
 func NewTLSClient(host, certPEM, keyPEM, caPEM string) (*Client, error) {
 	c, err := docker.NewTLSClient(host, certPEM, keyPEM, caPEM)
+	if err != nil {
+		return nil, err
+	}
+	return &Client{c}, nil
+}
+
+// NewTLSClientFromBytes create a client for a TLS secured Docker engine
+// The key and certificates are passed inline
+func NewTLSClientFromBytes(host string, certPEMBlock, keyPEMBlock, caPEMCert []byte) (*Client, error) {
+	c, err := docker.NewTLSClientFromBytes(host, certPEMBlock, keyPEMBlock, caPEMCert)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
See https://github.com/fsouza/go-dockerclient/blob/master/client.go#L172 for implementation of `NewTLSClientFromBytes()`